### PR TITLE
Add lein integration-test runner alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM clojure
+FROM clojure:openjdk-11-lein-2.9.1
 
 WORKDIR /usr/src/app
 
 COPY project.clj /usr/src/app/
 
 RUN lein deps
+
+COPY resources/proto /usr/src/app/resources/
+
+RUN lein protoc
 
 COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Leiningen:
 [com.quorumcontrol/tupelo-client "0.1.0-SNAPSHOT"]
 ```
 
+## Tests
+
+There are some RPC integration tests that can be run against a live Tupelo RPC
+server by running `lein integration-test`. Note that you will need a working
+Docker environment setup.
+
 ## License
 
 Copyright © 2018-2019 Quorum Control, GmbH

--- a/project.clj
+++ b/project.clj
@@ -11,10 +11,12 @@
                  [io.grpc/grpc-stub "1.18.0"]
                  [io.grpc/grpc-netty "1.18.0"]
                  [mvxcvi/clj-cbor "0.7.1"]]
-  :plugins [[lein-protoc "0.5.0"]]
+  :plugins [[lein-protoc "0.5.0"]
+            [lein-shell "0.5.0"]]
   :proto-source-paths ["resources/proto"]
   :protoc-version "3.6.1"
   :protoc-grpc {:version "1.17.1"}
   :java-source-paths ["target/generated-sources/protobuf"]
   :repl-options {:init-ns tupelo-client.core}
-  :profiles {:uberjar {:aot :all}})
+  :profiles {:uberjar {:aot :all}}
+  :aliases {"integration-test" ["shell" "scripts/integration-tests"]})

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/src quorumcontrol/tupelo-integration-runner


### PR DESCRIPTION
Adds an alias so the integration runner can be invoked via `lein integration-test`.